### PR TITLE
fix(rc): 修复空配置文件报错

### DIFF
--- a/src/default/rc.ts
+++ b/src/default/rc.ts
@@ -41,7 +41,7 @@ class Rc {
     // hack: 目的是取出 free-swaggerrc 中的代码片段
     /*eslint-disable*/
     let _obj = {};
-    eval(`_obj = ` + data.slice(EXPORT_DEFAULT.length));
+    eval(`_obj = ` + data.replace(new RegExp(`^${EXPORT_DEFAULT}`), ''));
     this.data = {
       ...this.getDefaultAnswer(),
       ..._obj


### PR DESCRIPTION
旧版配置和默认配置为 {}, slice 方式截取报错