### PR TITLE
增加config配置 propComment，配置interface中注释的位置

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -37,10 +37,11 @@ export const addUsingPOST = params =>
 
 | 参数             | 说明                      | 类型                     | 可选值      | 默认值                               |
 | ---------------- | ------------------------- | ------------------------ | ----------- | ------------------------------------ |
-| source           | 必选，swagger 源          | json                     | -           | -                                    |
+| source           | 必选，swagger 源          | json                    | -           | -                                    |
 | lang             | 可选，生成 api 语言       | string                   | "js" / "ts" | "js"                                 |
 | templateFunction | 可选，模版函数            | Function(TemplateConfig) | -           | 返回一个模版，用于生成自定义代码片段 |
-| useJsDoc         | 可选，是否添加 jsdoc 注释 | boolean                  |             | false                                |
+| useJsDoc         | 可选，是否添加 jsdoc 注释 | boolean                   |             | false                                |
+| propComment      | 可选，注释位置           | string                    |"head" / "tail" / null| "tail"                                |
 
 - TemplateConfig
 

--- a/packages/client/index.d.ts
+++ b/packages/client/index.d.ts
@@ -9,7 +9,8 @@ declare function freeSwaggerClient(
 
 declare function compileInterfaces(
   source: OpenAPIV2.Document,
-  interfaceName?: string
+  interfaceName?: string,
+  propComment?: string
 ): string
 
 declare function compileJsDocs(

--- a/packages/client/src/compile/interface.ts
+++ b/packages/client/src/compile/interface.ts
@@ -17,6 +17,7 @@ import { genInterface } from '../gen/interface'
 const compileInterface = (
   source: OpenAPIV2.Document,
   interfaceName: string,
+  propComment?: string,
   noContext = false
 ): string => {
   if (!source.definitions || shouldSkipGenerate(interfaceName, noContext))
@@ -24,7 +25,9 @@ const compileInterface = (
   parseInterface(source.definitions, interfaceName)
 
   try {
-    return formatCode('ts')(genInterface(findInterface(interfaceName)))
+    return formatCode('ts')(
+      genInterface(findInterface(interfaceName), propComment)
+    )
   } catch (e) {
     console.warn(
       `interfaceName: ${interfaceName} 生成失败，检查是否符合 swagger 规范`
@@ -40,13 +43,14 @@ const compileInterface = (
 // 生成全量 interface 代码
 const compileInterfaces = (
   source: OpenAPIV2.Document,
-  interfaceName?: string
+  interfaceName?: string,
+  propComment?: string
 ): string => {
   if (!source.definitions) return ''
   resetInterfaceMap()
 
   if (interfaceName) {
-    return compileInterface(source, interfaceName, true)
+    return compileInterface(source, interfaceName, propComment, true)
   } else {
     const headerCode = `/* eslint-disable */
     // @ts-nocheck
@@ -63,18 +67,20 @@ const compileInterfaces = (
     })
 
     const interfaceCode = Object.keys(map).reduce(
-      (acc, cur) => acc + compileInterface(source, cur),
+      (acc, cur) => acc + compileInterface(source, cur, propComment),
       ''
     )
 
     const recursiveInterfaceCode = Object.keys(recursiveMap).reduce(
-      (acc, cur) => acc + formatCode('ts')(genInterface(recursiveMap[cur])),
+      (acc, cur) =>
+        acc + formatCode('ts')(genInterface(recursiveMap[cur], propComment)),
       ''
     )
 
     const interfaceWithGenericCode = Object.keys(genericInterfaceMap).reduce(
       (acc, cur) =>
-        acc + formatCode('ts')(genInterface(genericInterfaceMap[cur])),
+        acc +
+        formatCode('ts')(genInterface(genericInterfaceMap[cur], propComment)),
       ''
     )
 

--- a/packages/client/src/gen/interface.ts
+++ b/packages/client/src/gen/interface.ts
@@ -1,18 +1,30 @@
 import { ParsedInterface } from '../..'
 
-const genInterface = ({ name, props, skipGenerate }: ParsedInterface): string =>
+const genInterface = (
+  { name, props, skipGenerate }: ParsedInterface,
+  propComment = 'tail'
+): string =>
   skipGenerate
     ? ''
     : `
     export interface ${name} {
-        ${Object.entries(props).map(
-          ([propName, prop]) =>
-            `
-            '${propName}' ${prop.required ? '' : '?'}: ${prop.type}  ${
-              prop.description && `// ${prop.description}`
+        ${Object.entries(props).map(([propName, prop]) => {
+          const { description, required, type } = prop
+          let headComment = ''
+          let tailComment = ''
+          if (description && propComment) {
+            if (propComment === 'head') {
+              headComment = `// ${description}\n`
+            } else if (propComment === 'tail') {
+              tailComment = ` // ${description}`
             }
-            `
-        )}
+          }
+
+          const requireMark = required ? '' : '?'
+          return `
+            ${headComment}'${propName}' ${requireMark}: ${type}${tailComment}
+          `
+        })}
       }
       `
 

--- a/packages/server/src/default/index.ts
+++ b/packages/server/src/default/index.ts
@@ -34,6 +34,7 @@ const getDefaultConfig = (
   chooseAll: false,
   useJsDoc: false,
   fileName: (name) => camelcase(name),
+  propComment: 'tail',
 })
 
 export const mergeDefaultConfig = async (

--- a/packages/server/src/default/rc.ts
+++ b/packages/server/src/default/rc.ts
@@ -72,7 +72,8 @@ class Rc {
             apiChoices: [],
             chooseAll: false,
             useJsDoc: false,
-            fileName: (name: string) => camelcase(name)
+            fileName: (name: string) => camelcase(name),
+            propComment: 'tail'
         };
     }
 

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -39,7 +39,10 @@ const gen = async (
   if (config.lang === 'ts') {
     const interfacePath = path.resolve(dirPath, INTERFACE_PATH)
     fse.ensureFileSync(interfacePath)
-    await fse.writeFile(interfacePath, compileInterfaces(config.source))
+    await fse.writeFile(
+      interfacePath,
+      compileInterfaces(config.source, undefined, config.propComment)
+    )
   }
 
   if (config.lang === 'js' && config.useJsDoc) {

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -14,6 +14,7 @@ export interface Config<T = string | OpenAPIV2.Document>
   customImportCode?: string
   chooseAll?: boolean
   fileName?(name: string): string
+  propComment?: 'head' | 'tail' | null
 }
 
 export interface MockConfig<T = string | OpenAPIV2.Document> {


### PR DESCRIPTION
增加配置使注释支持两种形式
```
# head

// comment
code: string
```
```
# tail

code: string // comment
```